### PR TITLE
Remove ConsoleLogger from all samples

### DIFF
--- a/samples/1-primitives-ts/src/app.ts
+++ b/samples/1-primitives-ts/src/app.ts
@@ -1,4 +1,4 @@
-import { Bot, ConsoleLogger, MemoryStorage, BotStateManager } from 'botbuilder';
+import { Bot, MemoryStorage, BotStateManager } from 'botbuilder';
 import { BotFrameworkAdapter } from 'botbuilder-services';
 import * as restify from 'restify';
 
@@ -14,7 +14,6 @@ server.post('/api/messages', adapter.listen() as any);
 
 // Initialize bot
 const bot = new Bot(adapter)
-    .use(new ConsoleLogger())
     .use(new MemoryStorage())
     .use(new BotStateManager())
     .onReceive(context => {

--- a/samples/2-topic-ts/src/app.ts
+++ b/samples/2-topic-ts/src/app.ts
@@ -1,5 +1,5 @@
 import * as restify from 'restify';
-import { Bot, ConsoleLogger, MemoryStorage, BotStateManager } from 'botbuilder';
+import { Bot, MemoryStorage, BotStateManager } from 'botbuilder';
 import { BotFrameworkAdapter } from 'botbuilder-services';
 import { RootTopic } from './topics/rootTopic';
 
@@ -15,7 +15,6 @@ server.post('/api/messages', adapter.listen() as any);
 
 // Initialize bot
 const bot = new Bot(adapter)
-    .use(new ConsoleLogger())
     .use(new MemoryStorage())
     .use(new BotStateManager())
     .onReceive((context) => {

--- a/samples/alarmbot-ts/src/app.ts
+++ b/samples/alarmbot-ts/src/app.ts
@@ -1,5 +1,5 @@
 import * as restify from 'restify';
-import { Bot, ConsoleLogger, MemoryStorage, BotStateManager } from 'botbuilder';
+import { Bot, MemoryStorage, BotStateManager } from 'botbuilder';
 import { BotFrameworkAdapter } from 'botbuilder-services';
 import { RootTopic } from './topics/rootTopic';
 
@@ -15,7 +15,6 @@ server.post('/api/messages', adapter.listen() as any);
 
 // Initialize bot
 const bot = new Bot(adapter)
-    .use(new ConsoleLogger())
     .use(new MemoryStorage())
     .use(new BotStateManager())
     .onReceive((context) => {


### PR DESCRIPTION
Fixes #1. The samples don't use the logger anyway.